### PR TITLE
1 2 boxing and pinning

### DIFF
--- a/1_concepts/1_1_default_clone_copy/src/main.rs
+++ b/1_concepts/1_1_default_clone_copy/src/main.rs
@@ -1,3 +1,44 @@
+#[derive(Debug, Copy, Clone, Default)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+impl Point {
+    fn new(x: f64, y: f64) -> Self {
+        Point { x, y }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Polyline {
+    points: Vec<Point>,
+    // to prevent Default derivation
+    _non_default: (),
+}
+
+impl Polyline {
+    fn new(points: Vec<Point>) -> Option<Polyline> {
+        match points.len() {
+            0 => None,
+            _ => Some(Polyline {
+                points,
+                _non_default: (),
+            }),
+        }
+    }
+}
+
 fn main() {
+    let p1 = Point::default();
+    let p2 = Point::new(1.0, 2.0);
+    let p3 = p2; // Copy works
+
+    // Polyline creation
+    let points = vec![p1, p2, p3];
+    let polyline = Polyline::new(points).unwrap();
+
+    let polyline_clone = polyline.clone(); // Clone works
+
     println!("Implement me!");
 }

--- a/1_concepts/1_2_box_pin/src/main.rs
+++ b/1_concepts/1_2_box_pin/src/main.rs
@@ -1,3 +1,107 @@
+use std::{default, f32::INFINITY, fmt, pin::Pin, process::exit, rc::Rc};
+
+// TASK: for the following types: Box<T>, Rc<T>, Vec<T>, String, &[u8], T.
+// Implement the following traits:
+trait SayHi: fmt::Debug {
+    fn say_hi(self: Pin<&Self>) {
+        println!("Hi from {:?}", self)
+    }
+}
+
+trait MutMeSomehow {
+    fn mut_me_somehow(self: Pin<&mut Self>) {
+        // Implementation must be meaningful, and
+        // obviously call something requiring `&mut self`.
+        // The point here is to practice dealing with
+        // `Pin<&mut Self>` -> `&mut self` conversion
+        // in different contexts, without introducing
+        // any `Unpin` trait bounds.
+    }
+}
+
+impl<T: fmt::Debug> SayHi for Box<T> {
+    fn say_hi(self: Pin<&Self>) {
+        println!("Redefined say_hi from Boxed_T: {:?}", self);
+    }
+}
+
+impl<T: fmt::Debug> SayHi for Rc<T> {
+    fn say_hi(self: Pin<&Self>) {
+        println!("Redefined say_hi from Rc_T: {:?}", self);
+    }
+}
+
+impl<T: fmt::Debug> SayHi for Vec<T> {
+    fn say_hi(self: Pin<&Self>) {
+        println!("Redefined say_hi from Vec_T: {:?}", self);
+    }
+}
+
+impl SayHi for String {
+    fn say_hi(self: Pin<&Self>) {
+        println!("Redefined say_hi from String");
+    }
+}
+
+impl SayHi for &[u8] {
+    // use default implementation
+}
+
+// we do not need to implement SayHi for T to avoid Rust coherence rules violation
+
+impl<T> MutMeSomehow for Box<T> {
+    fn mut_me_somehow(self: Pin<&mut Self>) {
+        let inner = unsafe { self.get_unchecked_mut() };
+        *inner = Box::new(unsafe { std::ptr::read(&**inner) });
+    }
+}
+
+// increment strong count (requires mutable access to the reference counter)
+impl<T> MutMeSomehow for Rc<T> {
+    fn mut_me_somehow(self: Pin<&mut Self>) {
+        let inner = unsafe { self.get_unchecked_mut() };
+        let _clone = inner.clone();
+    }
+}
+
+impl<T> MutMeSomehow for Vec<T> {
+    fn mut_me_somehow(self: Pin<&mut Self>) {
+        let inner = unsafe { self.get_unchecked_mut() };
+        inner.reverse();
+    }
+}
+
+impl MutMeSomehow for String {
+    fn mut_me_somehow(self: Pin<&mut Self>) {
+        let inner = unsafe { self.get_unchecked_mut() };
+        inner.insert(0, 'f');
+    }
+}
+
+// For &[u8] - modify through the mutable reference. But this is not safe
+impl MutMeSomehow for &[u8] {
+    fn mut_me_somehow(self: Pin<&mut Self>) {
+        let inner = unsafe { self.get_unchecked_mut() };
+        let _ = inner.iter().filter(|x| **x == 0);
+    }
+}
+
+//Commented because of conflict with implementation for type Box<> abowe
+// impl<T> MutMeSomehow for T
+// where
+//     T: Default,
+// {
+//     fn mut_me_somehow(self: Pin<&mut Self>) {
+//         let inner = unsafe { self.get_unchecked_mut() };
+//         *inner = T::default();
+//     }
+// }
+
 fn main() {
-    println!("Implement me!");
+    let mut s = String::from("older");
+    let pinned = Pin::new(&mut s);
+
+    // calls my implementation that ass char 'f' to the string
+    pinned.mut_me_somehow();
+    println!("{}", s); // Output: "folder"
 }


### PR DESCRIPTION
Resolves [Step 1_2](https://github.com/klausnat/rust_incub/tree/main/1_concepts/1_2_box_pin)


## Task

For the following types: Box<T>, Rc<T>, Vec<T>, String, &[u8], T.
Implement the following traits:

trait SayHi: fmt::Debug {
    fn say_hi(self: Pin<&Self>) {
        println!("Hi from {:?}", self)
    }
}

trait MutMeSomehow {
    fn mut_me_somehow(self: Pin<&mut Self>) {
        // Implementation must be meaningful, and
        // obviously call something requiring `&mut self`.
        // The point here is to practice dealing with
        // `Pin<&mut Self>` -> `&mut self` conversion
        // in different contexts, without introducing 
        // any `Unpin` trait bounds.
    }
}

For the following structure:

struct Measurable[Future](https://doc.rust-lang.org/std/future/trait.Future.html)<Fut> {
    inner_future: Fut,
    started_at: Option<std::time::Instant>,
}

Provide a Future trait implementation, transparently polling the inner_future, and printing its execution time in nanoseconds once it's ready. Using Fut: Unpin trait bound (or similar) is not allowed.



## Solution

No Unpin Bound used, as required
