### PR TITLE
Step 1.6: Static and dynamic dispatch

### DIFF
--- a/1_concepts/1_6_dispatch/src/lib.rs
+++ b/1_concepts/1_6_dispatch/src/lib.rs
@@ -1,0 +1,69 @@
+use std::borrow::Cow;
+
+// Storage: trait for common behavior
+pub trait Storage<K, V> {
+    fn set(&mut self, key: K, val: V);
+    fn get(&self, key: &K) -> Option<&V>;
+    fn remove(&mut self, key: &K) -> Option<V>;
+}
+
+#[derive(Debug)]
+pub struct User {
+    pub id: u64,
+    pub email: Cow<'static, str>,
+    pub activated: bool,
+}
+
+// Dynamic dispatch
+pub struct UserRepository {
+    pub storage: Box<dyn Storage<u64, User>>,
+}
+
+impl UserRepository {
+    pub fn new(storage: Box<dyn Storage<u64, User>>) -> Self {
+        UserRepository { storage }
+    }
+
+    pub fn add_user(&mut self, user: User) {
+        self.storage.set(user.id, user)
+    }
+
+    pub fn get_user(&self, id: &u64) -> Option<&User> {
+        self.storage.get(id)
+    }
+
+    pub fn update_user(&mut self, user: User) {
+        self.storage.set(user.id, user);
+    }
+
+    pub fn remove_user(&mut self, id: &u64) {
+        self.storage.remove(id);
+    }
+}
+
+// Static dispatch
+pub struct UserRepositoryStatic<T: Storage<u64, User>> {
+    pub storage: T,
+}
+
+impl<T: Storage<u64, User>> UserRepositoryStatic<T> {
+    pub fn new(storage: T) -> Self {
+        UserRepositoryStatic { storage }
+    }
+
+    pub fn add_user(&mut self, user: User) {
+        self.storage.set(user.id, user)
+    }
+
+    pub fn get_user(&self, id: &u64) -> Option<&User> {
+        self.storage.get(id)
+    }
+
+    pub fn update_user(&mut self, user: User) {
+        self.storage.set(user.id, user);
+    }
+
+    pub fn remove_user(&mut self, id: &u64) {
+        self.storage.remove(id);
+    }
+}

--- a/1_concepts/1_6_dispatch/src/main.rs
+++ b/1_concepts/1_6_dispatch/src/main.rs
@@ -1,3 +1,86 @@
+// TASK:
+// Given the following Storage abstraction and User entity:
+
+// trait Storage<K, V> {
+//     fn set(&mut self, key: K, val: V);
+//     fn get(&self, key: &K) -> Option<&V>;
+//     fn remove(&mut self, key: &K) -> Option<V>;
+// }
+
+// struct User {
+//     id: u64,
+//     email: Cow<'static, str>,
+//     activated: bool,
+// }
+
+use std::{borrow::Cow, collections::HashMap};
+
+// Implement UserRepository type with injectable Storage implementation,
+// which can get, add, update and remove User in the injected Storage.
+// Make two different implementations: one should use dynamic dispatch for Storage injecting,
+// and the other one should use static dispatch.
+use step_1_6::*;
 fn main() {
-    println!("Implement me!");
+    let user1 = User {
+        id: 1,
+        email: Cow::Borrowed("web@gmail.com"),
+        activated: true,
+    };
+
+    let user2 = User {
+        id: 2,
+        email: Cow::Borrowed("databada@gmail.com"),
+        activated: false,
+    };
+
+    let user3 = User {
+        id: 3,
+        email: Cow::Borrowed("boboobo@gmail.com"),
+        activated: true,
+    };
+
+    let user4 = User {
+        id: 4,
+        email: Cow::Borrowed("alabamala@gmail.com"),
+        activated: true,
+    };
+
+    #[derive(Default)]
+    struct HashMapStorage {
+        data: HashMap<u64, User>,
+    }
+
+    // Dynamic
+    impl Storage<u64, User> for HashMapStorage {
+        fn set(&mut self, key: u64, val: User) {
+            self.data.insert(key, val);
+        }
+
+        fn get(&self, key: &u64) -> Option<&User> {
+            self.data.get(key)
+        }
+
+        fn remove(&mut self, key: &u64) -> Option<User> {
+            self.data.remove(key)
+        }
+    }
+
+    let storage = Box::new(HashMapStorage::default());
+    let mut user_rep_dynamic: UserRepository = UserRepository::new(storage);
+
+    user_rep_dynamic.add_user(user1);
+    user_rep_dynamic.add_user(user2);
+
+    println!("Dynamic rep: {:?}", user_rep_dynamic.get_user(&2));
+
+    // Static
+
+    let storage_static = HashMapStorage::default();
+    let mut user_rep_static: UserRepositoryStatic<HashMapStorage> =
+        UserRepositoryStatic::new(storage_static);
+
+    user_rep_static.add_user(user3);
+    user_rep_static.add_user(user4);
+
+    println!("Static rep: {:?}", user_rep_static.get_user(&3));
 }


### PR DESCRIPTION
Resolves [Step 1_6](https://github.com/instrumentisto/rust-incubator/tree/main/1_concepts/1_6_dispatch)

## Task

Given the following Storage abstraction and User entity:

```
trait Storage<K, V> {
    fn set(&mut self, key: K, val: V);
    fn get(&self, key: &K) -> Option<&V>;
    fn remove(&mut self, key: &K) -> Option<V>;
}

struct User {
    id: u64,
    email: Cow<'static, str>,
    activated: bool,
}

```
Implement UserRepository type with injectable Storage implementation, which can get, add, update and remove User in the injected Storage. Make two different implementations: one should use [dynamic dispatch](https://en.wikipedia.org/wiki/Dynamic_dispatch) for Storage injecting, and the other one should use [static dispatch](https://en.wikipedia.org/wiki/Static_dispatch).




## Solution

Created both versions (dynamic and static dispatch). Work was separated into 2 files: main.rs and lib.rs