### PR TITLE
Step 2.1: Rich types ensure correctness

### DIFF
--- a/2_idioms/2_1_type_safety/Cargo.toml
+++ b/2_idioms/2_1_type_safety/Cargo.toml
@@ -3,3 +3,6 @@ name = "step_2_1"
 version = "0.1.0"
 edition = "2021"
 publish = false
+
+[dependencies]
+nutype = "0.6.2"

--- a/2_idioms/2_1_type_safety/src/main.rs
+++ b/2_idioms/2_1_type_safety/src/main.rs
@@ -1,40 +1,110 @@
+use std::marker::PhantomData;
+
+use crate::post::{Body, Deleted, Title, Unmoderated};
+
 mod post {
     #[derive(Clone, Debug, PartialEq)]
-    pub struct Id(u64);
+    pub struct Id(pub u64);
 
     #[derive(Clone, Debug, PartialEq)]
-    pub struct Title(String);
+    pub struct Title(pub String);
 
     #[derive(Clone, Debug, PartialEq)]
-    pub struct Body(String);
+    pub struct Body(pub String);
 
     // A series of zero-sized types representing the state of the post
-    struct ReadyForModeration;
-    struct Unmoderated;
-    struct Deleted;
-    struct Published;
-
-    
-    #[derive(Clone, Debug, PartialEq)]
-    pub enum State {
-        ReadyForModeration,
-        Unmoderated,
-        Deleted,
-        Published,
-    }
+    pub struct New;
+    pub struct Unmoderated;
+    pub struct Deleted;
+    pub struct Published;
 }
 mod user {
     #[derive(Clone, Debug, PartialEq)]
-    pub struct Id(u64);
+    pub struct Id(pub u64);
 }
 
 #[derive(Clone)]
-struct Post {
+struct Post<S> {
     id: post::Id,
     user_id: user::Id,
     title: post::Title,
     body: post::Body,
-    state: post::State,
+    state: PhantomData<S>,
 }
 
-fn main() {}
+impl Post<post::New> {
+    pub fn new(
+        id: post::Id,
+        user_id: user::Id,
+        title: post::Title,
+        body: post::Body,
+    ) -> Post<post::New> {
+        Post {
+            id,
+            user_id,
+            title,
+            body,
+            state: PhantomData,
+        }
+    }
+
+    pub fn publish(self) -> Post<post::Unmoderated> {
+        Post {
+            id: self.id,
+            user_id: self.user_id,
+            title: self.title,
+            body: self.body,
+            state: std::marker::PhantomData,
+        }
+    }
+}
+
+// these methods can be called only when post's state is Unmoderated
+impl Post<post::Unmoderated> {
+    pub fn allow(self) -> Post<post::Published> {
+        Post {
+            id: self.id,
+            user_id: self.user_id,
+            title: self.title,
+            body: self.body,
+            state: PhantomData,
+        }
+    }
+
+    pub fn deny(self) -> Post<post::Deleted> {
+        Post {
+            id: self.id,
+            user_id: self.user_id,
+            title: self.title,
+            body: self.body,
+            state: PhantomData,
+        }
+    }
+}
+
+impl Post<post::Published> {
+    pub fn delete(self) -> Post<post::Deleted> {
+        Post {
+            id: self.id,
+            user_id: self.user_id,
+            title: self.title,
+            body: self.body,
+            state: PhantomData,
+        }
+    }
+}
+fn main() {
+       let new_post = Post::new(
+        post::Id(1),
+        user::Id(1),
+        post::Title("Title".to_string()),
+        post::Body("Content".to_string()),
+    );
+
+    let res = new_post.publish().allow().delete();
+
+    // res.deny(); // wouldn't compile.
+    
+    // let unmoderated = new_post.allow();  // wouldn't compile
+    // new_post.delete();  // wouldn't compile
+}

--- a/2_idioms/2_1_type_safety/src/main.rs
+++ b/2_idioms/2_1_type_safety/src/main.rs
@@ -1,3 +1,40 @@
-fn main() {
-    println!("Implement me!");
+mod post {
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct Id(u64);
+
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct Title(String);
+
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct Body(String);
+
+    // A series of zero-sized types representing the state of the post
+    struct ReadyForModeration;
+    struct Unmoderated;
+    struct Deleted;
+    struct Published;
+
+    
+    #[derive(Clone, Debug, PartialEq)]
+    pub enum State {
+        ReadyForModeration,
+        Unmoderated,
+        Deleted,
+        Published,
+    }
 }
+mod user {
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct Id(u64);
+}
+
+#[derive(Clone)]
+struct Post {
+    id: post::Id,
+    user_id: user::Id,
+    title: post::Title,
+    body: post::Body,
+    state: post::State,
+}
+
+fn main() {}


### PR DESCRIPTION
Resolves [Step 2_1](https://github.com/instrumentisto/rust-incubator/tree/main/2_idioms/2_1_type_safety)

## Task

For the Post type described above, assume the following behavior in our application:
```

+-----+              +-------------+            +-----------+
| New |--publish()-->| Unmoderated |--allow()-->| Published |
+-----+              +-------------+            +-----------+
                           |                          |
                         deny()                    delete()
                           |       +---------+        |
                           +------>| Deleted |<-------+
                                   +---------+
```

Implement this behavior using [typestates idiom](https://yoric.github.io/post/rust-typestate), so that calling delete() on New post (or calling deny() on Deleted post) will be a compile-time error.




## Solution

used PhantomData and typestates pattern and newtype pattern.