### PR TITLE
Step 2.6: Sealing

### DIFF
--- a/2_idioms/2_4_generic_in_type_out/src/main.rs
+++ b/2_idioms/2_4_generic_in_type_out/src/main.rs
@@ -3,7 +3,7 @@ use std::net::{IpAddr, SocketAddr};
 fn main() {
     println!("Refactor me!");
 
-    let mut err = Error::new("NO_USER".to_string());
+    let err = Error::new("NO_USER".to_string());
     err.status(404).message("User not found".to_string());
 }
 
@@ -15,30 +15,30 @@ pub struct Error {
 }
 
 impl Default for Error {
-    #[inline]
     fn default() -> Self {
         Self {
-            code: "UNKNOWN".to_string(),
+            code: "UNKNOWN".into(),
             status: 500,
-            message: "Unknown error has happened.".to_string(),
+            message: "Unknown error has happened.".into(),
         }
     }
 }
 
 impl Error {
-    pub fn new(code: String) -> Self {
-        let mut err = Self::default();
-        err.code = code;
-        err
+    pub fn new<S: Into<String>>(code: S) -> Self {
+        Self {
+            code: code.into(),
+            ..Self::default()
+        }
     }
 
-    pub fn status(&mut self, s: u16) -> &mut Self {
+    pub fn status(mut self, s: u16) -> Self {
         self.status = s;
         self
     }
 
-    pub fn message(&mut self, m: String) -> &mut Self {
-        self.message = m;
+    pub fn message<S: Into<String>>(mut self, m: S) -> Self {
+        self.message = m.into();
         self
     }
 }
@@ -47,8 +47,8 @@ impl Error {
 pub struct Server(Option<SocketAddr>);
 
 impl Server {
-    pub fn bind(&mut self, ip: IpAddr, port: u16) {
-        self.0 = Some(SocketAddr::new(ip, port))
+    pub fn bind(&mut self, ip: impl Into<IpAddr>, port: u16) {
+        self.0 = Some(SocketAddr::new(ip.into(), port))
     }
 }
 
@@ -65,11 +65,11 @@ mod server_spec {
         fn sets_provided_address_to_server() {
             let mut server = Server::default();
 
-            server.bind(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+            server.bind(Ipv4Addr::new(127, 0, 0, 1), 8080);
             assert_eq!(format!("{}", server.0.unwrap()), "127.0.0.1:8080");
 
-            server.bind("::1".parse().unwrap(), 9911);
-            assert_eq!(format!("{}", server.0.unwrap()), "[::1]:9911");
+            server.bind("::1".parse::<IpAddr>().unwrap(), 9911);
+            assert_eq!(server.0.unwrap().to_string(), "[::1]:9911");
         }
     }
 }

--- a/2_idioms/2_6_sealing/src/lib.rs
+++ b/2_idioms/2_6_sealing/src/lib.rs
@@ -1,4 +1,67 @@
 pub mod my_error;
 pub mod my_iterator_ext;
 
+use std::{any::TypeId, ffi::os_str::Display};
+
 pub use self::{my_error::MyError, my_iterator_ext::MyIteratorExt};
+
+/// ```compile_fail
+/// // we were able to impl private::Sealed for types in my_iterator_ext,
+/// // but we are not able to do it in downstream crates
+/// impl my_iterator_ext::private::Sealed for DownStreamType {} // shouldn't compile!
+/// ```
+
+struct DownStreamType {}
+impl Iterator for DownStreamType {
+    type Item = ();
+    fn next(&mut self) -> Option<Self::Item> {
+        None
+    }
+}
+
+// compile_fail, MyIteratorExt is Sealed
+// impl MyIteratorExt for DownStreamType {
+//     fn format(self, sep: &str) -> Format<Self>
+//     where
+//         Self: Sized,
+//     {
+//         format::new_format_default(self, sep)
+//     }
+
+//     fn format_with<F>(self, sep: &str, format: F) -> FormatWith<Self, F>
+//     where
+//         Self: Sized,
+//         F: FnMut(Self::Item, &mut dyn FnMut(&dyn std::fmt::Display) -> std::fmt::Result) -> std::fmt::Result,
+//     {
+//         format::new_format(self, sep, format)
+//     }
+// }
+
+// compile_fail, module format is private
+// fn use_sealed(
+//     value: impl my_iterator_ext::MyIteratorExt,
+// ) -> my_iterator_ext::format::Format<'_, impl my_iterator_ext::MyIteratorExt> {
+//     value.format("separator")
+// }
+
+#[derive(Debug)]
+pub struct DownStreamType2 {}
+impl std::fmt::Display for DownStreamType2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        todo!()
+    }
+}
+
+impl MyError for DownStreamType2 {
+    fn source(&self) -> Option<&(dyn MyError + 'static)> {
+        None
+    }
+
+    // Can not implement method because of type private::Token
+    // fn type_id(&self, _: my_error::private::Token) -> std::any::TypeId
+    // where
+    //     Self: 'static,
+    // {
+    //     TypeId::of::<Self>()
+    // }
+}

--- a/2_idioms/2_6_sealing/src/my_error.rs
+++ b/2_idioms/2_6_sealing/src/my_error.rs
@@ -6,6 +6,10 @@ use std::{
     fmt::{Debug, Display},
 };
 
+mod private {
+    pub struct Token;
+}
+
 /// Basic expectations for error values.
 pub trait MyError: Debug + Display {
     /// The lower-level source of this error, if any.
@@ -67,7 +71,7 @@ pub trait MyError: Debug + Display {
     ///
     /// __This is memory-unsafe to override in user code.__
     #[doc(hidden)]
-    fn type_id(&self) -> TypeId
+    fn type_id(&self, _: private::Token) -> TypeId
     where
         Self: 'static,
     {
@@ -78,5 +82,26 @@ pub trait MyError: Debug + Display {
 impl<'a, T: MyError + ?Sized> MyError for &'a T {
     fn source(&self) -> Option<&(dyn MyError + 'static)> {
         MyError::source(&**self)
+    }
+}
+
+#[derive(Debug)]
+struct TypeImplsTraitMyError{}
+impl Display for TypeImplsTraitMyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        todo!()
+    }
+}
+
+impl MyError for TypeImplsTraitMyError {
+    fn source(&self) -> Option<&(dyn MyError + 'static)> {
+        None
+    }
+
+    fn type_id(&self, _: private::Token) -> TypeId
+    where
+        Self: 'static,
+    {
+        TypeId::of::<Self>()
     }
 }

--- a/2_idioms/2_6_sealing/src/my_iterator_ext.rs
+++ b/2_idioms/2_6_sealing/src/my_iterator_ext.rs
@@ -8,8 +8,12 @@ use std::fmt;
 
 use self::format::{Format, FormatWith};
 
+mod private {
+    pub trait Sealed {}
+}
+
 /// Extension trait for an [`Iterator`].
-pub trait MyIteratorExt: Iterator {
+pub trait MyIteratorExt: Iterator + private::Sealed {
     /// Format all iterator elements, separated by `sep`.
     ///
     /// All elements are formatted (any formatting trait)
@@ -69,6 +73,8 @@ pub trait MyIteratorExt: Iterator {
         format::new_format(self, sep, format)
     }
 }
+
+impl<T> private::Sealed for T where T: Iterator {}
 
 impl<T> MyIteratorExt for T where T: Iterator {}
 


### PR DESCRIPTION
Resolves [Step 2_6_sealing](https://github.com/instrumentisto/rust-incubator/tree/main/2_idioms/2_6_sealing)




## Task

Seal the traits defined in [this step's crate](https://github.com/instrumentisto/rust-incubator/blob/main/2_idioms/2_6_sealing/src/lib.rs) in the following way:

-     Make the [MyIteratorExt trait](https://github.com/instrumentisto/rust-incubator/blob/main/2_idioms/2_6_sealing/src/my_iterator_ext.rs) fully sealed. Do it manually, using the [sealed](https://docs.rs/sealed) crate or a similar one is not allowed.
-     Make the [MyError trait](https://github.com/instrumentisto/rust-incubator/blob/main/2_idioms/2_6_sealing/src/my_error.rs) partially sealed. Only seal the method marked with #[doc(hidden)] attribute.
-     Sealing should work on both module level (disallowing to implement the sealed trait or the sealed method in the root module of the crate or any other module outside the one where the traits are defined, prove it by providing commented implementations in the root module of the crate, which doesn't compile due to the seal, if uncommented) and crate level (prove it by creating [documentation tests which doesn't compile](https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#attributes) due to the seal).




## Solution

Used this recommended [article](https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/#what-are-sealed-traits)
trait in my_iterator_ext was sealed with supertrait,
and trait in my_error was partially sealed (only method) with private field.
