### PR TITLE
Step 3.4: Regular expressions and custom parsers

### DIFF
--- a/3_ecosystem/3_4_regex_parsing/Cargo.toml
+++ b/3_ecosystem/3_4_regex_parsing/Cargo.toml
@@ -3,3 +3,8 @@ name = "step_3_4"
 version = "0.1.0"
 edition = "2021"
 publish = false
+
+[dependencies]
+nom = "8.0.0"
+once_cell = "1.21.3"
+regex = "1.11.2"

--- a/3_ecosystem/3_4_regex_parsing/src/lib.rs
+++ b/3_ecosystem/3_4_regex_parsing/src/lib.rs
@@ -1,0 +1,180 @@
+use nom::{
+    IResult, Parser,
+    branch::alt,
+    bytes::complete::{tag, take_while, take_while_m_n, take_while1},
+    character::complete::{digit1, one_of},
+    combinator::{map_res, opt, peek, recognize},
+    sequence::{preceded, tuple},
+};
+
+fn parse(input: &str) -> (Option<Sign>, Option<usize>, Option<Precision>) {
+    let sign = parse_sign(input).map(|(_, sign)| sign).ok();
+    let width = parse_width(input).map(|(_, width)| width).ok().flatten();
+    let precision = parse_precision(input).map(|(_, prec)| prec).ok().flatten();
+
+    (sign, width, precision)
+}
+
+fn parse_sign(input: &str) -> IResult<&str, Sign> {
+    let (input, _) = skip_until_sign(input)?;
+    let (input, sign_char) = one_of("+-")(input)?;
+
+    let sign = match sign_char {
+        '+' => Sign::Plus,
+        '-' => Sign::Minus,
+        _ => unreachable!(),
+    };
+
+    Ok((input, sign))
+}
+
+fn skip_until_sign(input: &str) -> IResult<&str, ()> {
+    // Use take_while (without 1) to allow zero characters
+    let (input, _) = take_while(|c: char| !"+-".contains(c) && !c.is_whitespace())(input)?;
+    Ok((input, ()))
+}
+
+fn parse_width(input: &str) -> IResult<&str, Option<usize>> {
+    // Взять только цифры, отбросить лишнее до цифр
+    let (input, _) = take_while(|c: char| !c.is_ascii_digit() && "<^>+#-".contains(c))(input)?;
+
+    // отбросить все, что после точки (т.к после точки начинается Precision)
+    let (_, input) = take_while(|c: char| !".".contains(c))(input)?;
+
+    // Now look for width digits with explicit type annotation
+    let (input, width_str) = match digit1::<_, nom::error::Error<&str>>(input) {
+        Ok((input, digits)) => {
+            println!("INSIDE OK");
+            (input, digits)
+        }
+        Err(_) => return Ok((input, None)),
+    };
+
+    // Check if these digits are actually a width (not part of something else)
+    if input.starts_with('$') || input.starts_with('.') {
+        Ok((input, None)) // This is probably a precision parameter, not width
+    } else if let Ok(width) = width_str.parse() {
+        Ok((input, Some(width)))
+    } else {
+        Ok((input, None))
+    }
+}
+fn parse_precision(input: &str) -> IResult<&str, Option<Precision>> {
+    // Look for the '.' prefix
+    let (input, _) = take_while(|c: char| c != '.')(input)?;
+    let (input, _) = tag(".")(input)?;
+
+    // Parse what comes after the dot
+    let result = alt((
+        // Asterisk case
+        map_tag("*", Precision::Asterisk),
+        // Parameter case (ends with $)
+        map_parameter,
+        // Integer case
+        map_integer_precision,
+    ))
+    .parse(input);
+
+    match result {
+        Ok((input, precision)) => Ok((input, Some(precision))),
+        Err(_) => Ok((input, None)),
+    }
+}
+
+fn map_tag<'a, O>(tag_str: &'static str, value: O) -> impl Fn(&'a str) -> IResult<&'a str, O>
+where
+    O: Clone,
+{
+    move |input| {
+        let (input, _) = tag(tag_str)(input)?;
+        Ok((input, value.clone()))
+    }
+}
+
+fn map_parameter(input: &str) -> IResult<&str, Precision> {
+    let (input, num_str) = digit1(input)?;
+    let (input, _) = tag("$")(input)?;
+
+    if let Ok(arg_num) = num_str.parse() {
+        Ok((input, Precision::Argument(arg_num)))
+    } else {
+        Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Digit,
+        )))
+    }
+}
+
+fn map_integer_precision(input: &str) -> IResult<&str, Precision> {
+    let (input, num_str) = digit1(input)?;
+
+    if let Ok(precision) = num_str.parse() {
+        Ok((input, Precision::Integer(precision)))
+    } else {
+        Err(nom::Err::Error(nom::error::Error::new(
+            input,
+            nom::error::ErrorKind::Digit,
+        )))
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum Sign {
+    Plus,
+    Minus,
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+enum Precision {
+    Integer(usize),
+    Argument(usize),
+    Asterisk,
+}
+
+#[cfg(test)]
+mod spec {
+    use super::*;
+
+    #[test]
+    fn parses_sign() {
+        for (input, expected) in vec![
+            ("", None),
+            (">8.*", None),
+            (">+8.*", Some(Sign::Plus)),
+            ("-.1$x", Some(Sign::Minus)),
+            ("a^#043.8?", None),
+        ] {
+            let (sign, ..) = parse(input);
+            assert_eq!(sign, expected);
+        }
+    }
+
+    #[test]
+    fn parses_width() {
+        for (input, expected) in vec![
+            ("", None),
+            (">8.*", Some(8)),
+            (">+9.*", Some(9)),
+            ("-.1$x", None),
+            //("a^#043.8?", Some(43)),
+            ("a^#043.8?", Some(43)),
+        ] {
+            let (_, width, _) = parse(input);
+            assert_eq!(width, expected);
+        }
+    }
+
+    #[test]
+    fn parses_precision() {
+        for (input, expected) in vec![
+            ("", None),
+            (">8.*", Some(Precision::Asterisk)),
+            (">+8.*", Some(Precision::Asterisk)),
+            ("-.1$x", Some(Precision::Argument(1))),
+            ("a^#043.8?", Some(Precision::Integer(8))),
+        ] {
+            let (_, _, precision) = parse(input);
+            assert_eq!(precision, expected);
+        }
+    }
+}

--- a/3_ecosystem/3_4_regex_parsing/src/main.rs
+++ b/3_ecosystem/3_4_regex_parsing/src/main.rs
@@ -1,12 +1,146 @@
+use std::fmt::Error;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+// nom crate-based implementation
+use nom::{
+    branch::alt,
+    bytes::{take_while, take_while1, tag},
+    character::complete::char,
+    combinator::{map, opt, value},
+    error::ErrorKind,
+    IResult, Parser,
+};
+
+fn parse_sign_nom(input: &str) -> IResult<&str, Option<Sign>> {
+    let mut parser = opt(alt((
+        map(char('+'), |_| Sign::Plus),
+        map(char('-'), |_| Sign::Minus),
+    )));
+    parser.parse(input)
+}
+
+// Тестирование
 fn main() {
-    println!("Implement me!");
+    let test_sign_1 = [
+        ("+", Some(Sign::Plus)),
+        ("-", Some(Sign::Minus)),
+        ("", None),
+        ("abc", None),
+    ];
+
+    for (input, expected) in test_sign_1 {
+        let result = parse_sign_nom(input);
+        println!("Input: '{}'", input);
+        match result {
+            Ok((remaining, sign)) => {
+                println!("Success: {:?}, Remaining: '{}'", sign, remaining);
+                assert_eq!(sign, expected);
+            }
+            Err(e) => {
+                println!("Error: {:?}", e);
+                assert_eq!(None, expected);
+            }
+        }
+        println!("---");
+    }
+
+}
+
+// Regex-based implementation
+
+// To omit unnecessary performance penalty we should compile regular expression once and reuse its compilation result
+static REGEX_SIGN: Lazy<Regex> = Lazy::new(|| Regex::new("[+-]").unwrap()); // compiles once on the first use
+
+impl From<regex::Match<'_>> for Sign {
+    fn from(value: regex::Match<'_>) -> Self {
+        let res = value.as_str();
+        match res {
+            "+" => Sign::Plus,
+            "-" => Sign::Minus,
+            _ => panic!("something went wrong"),
+        }
+    }
+}
+
+static REGEX_PRECISION: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\.(?:(?:\d+|\w+)\$|\*|\d+)").unwrap()); // compiles once on the first use
+
+fn is_precision(input: &str) -> bool {
+    REGEX_PRECISION.is_match(input)
+}
+
+static REGEX_WIDTH: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?:^|[\s<^>+#-])(\d+)(?:$|[.\]])").unwrap()); // compiles once on the first use
+
+fn is_width(input: &str) -> bool {
+    REGEX_WIDTH.is_match(input)
+}
+
+fn parse_sign(input: &str) -> Option<Sign> {
+    if let Some(mat) = REGEX_SIGN.find(input) {
+        Some(mat.into())
+    } else {
+        None
+    }
+}
+
+fn parse_width(input: &str) -> Option<usize> {
+    if let Some(caps) = REGEX_WIDTH.captures(input) {
+        if let Some(width_match) = caps.get(1) {
+            return width_match.as_str().parse::<usize>().ok();
+        }
+    }
+
+    None
+}
+
+fn parse_precision(input: &str) -> Option<Precision> {
+    if let Some(mat) = REGEX_PRECISION.find(input) {
+        let intermed = mat.as_str();
+        match intermed {
+            // If Precision is Asterisk
+            ".*" => Some(Precision::Asterisk),
+
+            // If Precision is Argument
+            s if s.ends_with('$') => {
+                let arg_no_dollar = s.trim_end_matches('$');
+                let arg = arg_no_dollar.trim_start_matches('.');
+                if let Ok(num) = arg.parse::<usize>() {
+                    Some(Precision::Argument(num))
+                } else {
+                    None //Some(Precision::Argument(arg.parse::<usize>))
+                }
+            }
+
+            // If Precision is Integer
+            s => {
+                let arg = s.trim_start_matches('.');
+                if let Ok(num) = arg.parse::<usize>() {
+                    Some(Precision::Integer(num))
+                } else {
+                    None
+                }
+            }
+            _ => {
+                println!("THIS PRECISION IS UNCATCHED: {:?}", mat.as_str());
+                None
+            }
+        }
+    } else {
+        None
+    }
 }
 
 fn parse(input: &str) -> (Option<Sign>, Option<usize>, Option<Precision>) {
-    unimplemented!()
+    let parsed_sign = parse_sign(input);
+    let parsed_width = parse_width(input);
+    let parsed_precision = parse_precision(input);
+    (parsed_sign, parsed_width, parsed_precision)
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 enum Sign {
     Plus,
     Minus,


### PR DESCRIPTION
Resolves [Step 3.4](https://github.com/instrumentisto/rust-incubator/tree/main/3_ecosystem/3_4_regex_parsing)

## Task

Implement a parser to parse sign, width and precision from a given input (assumed to be a format_spec).

## Solution

In file lib.rs there is an implementation using a nom crate
In main.rs - REGEX-based implementation