### PR TITLE
Step 3.8: Logging and tracing

### DIFF
--- a/3_ecosystem/3_8_log/Cargo.toml
+++ b/3_ecosystem/3_8_log/Cargo.toml
@@ -3,3 +3,12 @@ name = "step_3_8"
 version = "0.1.0"
 edition = "2021"
 publish = false
+
+[dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.145"
+tracing = "0.1.41"
+tracing-appender = "0.2.3"
+tracing-core = "0.1.34"
+tracing-subscriber = { version = "0.3.20", features = ["fmt", "json", "env-filter"] }

--- a/3_ecosystem/3_8_log/access.log
+++ b/3_ecosystem/3_8_log/access.log
@@ -1,0 +1,4 @@
+{"timestamp":"2025-09-25T11:28:50.811989271Z","level":"DEBUG","fields":{"lvl":"DEBUG","file":"app.log","time":true,"message":"some debug information","method":"POST","path":"http://hello.com"},"target":"step_3_8"}
+{"timestamp":"2025-09-25T11:28:50.812069030Z","level":"INFO","fields":{"lvl":"INFO","file":"app.log","time":true,"message":"some info message","method":"POST","path":"http://hello.com"},"target":"step_3_8"}
+{"timestamp":"2025-09-25T11:28:50.812087120Z","level":"ERROR","fields":{"lvl":"ERROR","file":"app.log","time":true,"message":"some Error message"},"target":"step_3_8"}
+{"timestamp":"2025-09-25T11:28:50.812135811Z","level":"WARN","fields":{"lvl":"WARNING","file":"app.log","time":true,"message":"some warning message"},"target":"step_3_8"}

--- a/3_ecosystem/3_8_log/src/main.rs
+++ b/3_ecosystem/3_8_log/src/main.rs
@@ -1,3 +1,104 @@
+use std::time::SystemTime;
+use std::{fs::File, sync::Arc};
+
+use tracing::{debug, error, info, warn};
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::fmt::time::FormatTime;
+use tracing_subscriber::{fmt, prelude::*, Layer};
+
+use chrono::{DateTime, Utc};
+
+// Custom timer for nanosecond precision
+struct NanoTimer;
+
+impl FormatTime for NanoTimer {
+    fn format_time(&self, w: &mut tracing_subscriber::fmt::format::Writer<'_>) -> std::fmt::Result {
+        let now = SystemTime::now();
+        let datetime: DateTime<Utc> = now.into();
+        write!(w, "{}", datetime.to_rfc3339_opts(chrono::SecondsFormat::Nanos, true))
+    }
+}
+
+
 fn main() {
-    println!("Implement me!");
+    setup_logging().unwrap();
+
+    debug!(
+        lvl = "DEBUG",
+        file = "app.log",
+        message = "some debug information",
+        method = "POST",
+        path = "http://hello.com"
+    );
+
+    info!(
+        lvl = "INFO",
+        file = "app.log",
+        message = "some info message",
+        method = "POST",
+        path = "http://hello.com"
+    );
+
+    error!(
+        lvl = "ERROR",
+        file = "app.log",
+        message = "some Error message",
+    );
+
+    warn!(
+        lvl = "WARNING",
+        file = "app.log",
+        message = "some warning message",
+    );
+}
+
+// Main function to set up both loggers
+pub fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
+    // Create the access.log file appender
+    let access_log = File::create("access.log")?;
+    let access_log = Arc::new(access_log);
+
+    let timer = NanoTimer;
+
+    // Main app loggers: WARN+ to STDERR, others to STDOUT
+    // 1. STDOUT layer: INFO and DEBUG levels
+    let stdout_layer = fmt::layer()
+        .json()
+        .with_timer(timer)
+        .with_writer(std::io::stdout)
+        .with_filter(LevelFilter::INFO) // Minimum level: INFO
+        .with_filter(tracing_subscriber::filter::filter_fn(|metadata| {
+            // Only allow INFO and DEBUG levels to STDOUT
+            *metadata.level() <= tracing::Level::INFO
+        }));
+
+    // 2. STDERR layer: WARN and ERROR levels
+    let stderr_layer = fmt::layer()
+        .json()
+        .with_timer(NanoTimer)
+        .with_writer(std::io::stderr)
+        .with_filter(LevelFilter::WARN) // Minimum level: WARN
+        .with_filter(tracing_subscriber::filter::filter_fn(|metadata| {
+            // Only allow WARN and ERROR levels to STDERR
+            *metadata.level() >= tracing::Level::WARN
+        }));
+
+    // 3. Access logger: all logs to access.log file
+    let access_layer = fmt::layer()
+        .json()
+        .with_timer(NanoTimer)
+        .with_writer(move || access_log.clone())
+        .with_filter(tracing_subscriber::filter::filter_fn(|_metadata| {
+            true // Log everything to access.log for now
+        }));
+
+    // Combine both layers and initialize the subscriber
+    let subscriber = tracing_subscriber::registry()
+        .with(stdout_layer)
+        .with(stderr_layer)
+        .with(access_layer);
+
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    Ok(())
 }


### PR DESCRIPTION
Resolves [Step 3_8](https://github.com/instrumentisto/rust-incubator/tree/main/3_ecosystem/3_8_log)

## Task

Implement two loggers:

    Global main app.log logger which prints all its logs to STDOUT, but WARN level (and higher) logs to STDERR.
    Local access.log logger which writes all its logs to access.log file.

All logs should be structured and logged in a JSON format, and have time field with nanoseconds ([RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) formatted).

Examples:

{"lvl":"ERROR","file":"app.log","time":"2018-07-30T12:14:14.196483657Z","msg":"Error occurred"}
{"lvl":"INFO","file":"access.log","time":"2018-07-30T12:17:18.721127239Z","msg":"http","method":"POST","path":"/some"}

## Solution

Used tracing crate. Learned how to create Filters, Subscribers and Layers