### PR TITLE
Step 4.3: API servers, clients and tools

### DIFF
--- a/4_backend/4_3_api/.gitignore
+++ b/4_backend/4_3_api/.gitignore
@@ -1,0 +1,13 @@
+/.idea/
+/.vscode/
+/*.iml
+.DS_Store
+
+/Cargo.lock
+/target/
+
+**/*.rs.bk
+
+*.pdb
+
+.rust-analyzer/

--- a/4_backend/4_3_api/Cargo.toml
+++ b/4_backend/4_3_api/Cargo.toml
@@ -3,3 +3,15 @@ name = "step_4_3"
 version = "0.1.0"
 edition = "2021"
 publish = false
+
+[workspace]
+members = ["crates/shared", "crates/server", "crates/client"]
+resolver = "2"
+
+[workspace.dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1.0", features = ["full"] }
+utoipa = { version = "4.0", features = ["actix_extras", "chrono"] }
+utoipa-swagger-ui = "5.0"
+chrono = { version = "0.4", features = ["serde"] }

--- a/4_backend/4_3_api/crates/client/Cargo.toml
+++ b/4_backend/4_3_api/crates/client/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "client"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+clap = { version = "4.4", features = ["derive"] }
+reqwest = { version = "0.11", features = ["json"] }
+tokio = { version = "1.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+shared = { path = "../shared" }

--- a/4_backend/4_3_api/crates/client/src/main.rs
+++ b/4_backend/4_3_api/crates/client/src/main.rs
@@ -1,0 +1,260 @@
+use clap::{Parser, Subcommand};
+use shared::{
+    User, CreateUserRequest, UpdateUserRequest, Role, CreateRoleRequest, UpdateRoleRequest,
+    AddRoleToUserRequest, ApiResponse,
+};
+use reqwest::Client;
+use std::process;
+
+const BASE_URL: &str = "http://localhost:8080/api";
+
+#[derive(Parser)]
+#[command(name = "user-management-cli")]
+#[command(about = "CLI client for user management API", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// User management commands
+    User {
+        #[command(subcommand)]
+        action: UserCommands,
+    },
+    /// Role management commands  
+    Role {
+        #[command(subcommand)]
+        action: RoleCommands,
+    },
+    /// User-Role relationship commands
+    UserRole {
+        #[command(subcommand)]
+        action: UserRoleCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum UserCommands {
+    /// Create a new user
+    Create { username: String, email: String },
+    /// Get a user by ID
+    Get { id: i32 },
+    /// List all users
+    List,
+    /// Update a user
+    Update { id: i32, username: String },
+    /// Delete a user
+    Delete { id: i32 },
+}
+
+#[derive(Subcommand)]
+enum RoleCommands {
+    /// Create a new role
+    Create { slug: String, name: String },
+    /// Get a role by slug
+    Get { slug: String },
+    /// List all roles
+    List,
+    /// Update a role
+    Update { slug: String, name: String },
+    /// Delete a role
+    Delete { slug: String },
+}
+
+#[derive(Subcommand)]
+enum UserRoleCommands {
+    /// Add a role to a user
+    Add { user_id: i32, role_slug: String },
+    /// Remove a role from a user
+    Remove { user_id: i32, role_slug: String },
+    /// Get all roles for a user
+    Get { user_id: i32 },
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+    
+    let http_client = Client::new();
+    
+    match cli.command {
+        Commands::User { action } => handle_user_commands(http_client, action).await,
+        Commands::Role { action } => handle_role_commands(http_client, action).await,
+        Commands::UserRole { action } => handle_user_role_commands(http_client, action).await,
+    }
+}
+
+async fn handle_user_commands(client: Client, action: UserCommands) -> Result<(), Box<dyn std::error::Error>> {
+    match action {
+        UserCommands::Create { username, email } => {
+            let request = CreateUserRequest { username, email };
+            let response: ApiResponse<User> = client
+                .post(&format!("{}/users", BASE_URL))
+                .json(&request)
+                .send()
+                .await?
+                .json()
+                .await?;
+            
+            display_response(response);
+        }
+        UserCommands::Get { id } => {
+            let response: ApiResponse<User> = client
+                .get(&format!("{}/users/{}", BASE_URL, id))
+                .send()
+                .await?
+                .json()
+                .await?;
+            
+            display_response(response);
+        }
+        UserCommands::List => {
+            let response: ApiResponse<Vec<User>> = client
+                .get(&format!("{}/users", BASE_URL))
+                .send()
+                .await?
+                .json()
+                .await?;
+            
+            display_response(response);
+        }
+        UserCommands::Update { id, username } => {
+            let request = UpdateUserRequest { username };
+            let response: ApiResponse<User> = client
+                .put(&format!("{}/users/{}", BASE_URL, id))
+                .json(&request)
+                .send()
+                .await?
+                .json()
+                .await?;
+            
+            display_response(response);
+        }
+        UserCommands::Delete { id } => {
+            let response: ApiResponse<String> = client
+                .delete(&format!("{}/users/{}", BASE_URL, id))
+                .send()
+                .await?
+                .json()
+                .await?;
+            
+            display_response(response);
+        }
+    }
+    
+    Ok(())
+}
+
+async fn handle_role_commands(client: Client, action: RoleCommands) -> Result<(), Box<dyn std::error::Error>> {
+    match action {
+        RoleCommands::Create { slug, name } => {
+            let request = CreateRoleRequest { slug, name };
+            let response: ApiResponse<Role> = client
+                .post(&format!("{}/roles", BASE_URL))
+                .json(&request)
+                .send()
+                .await?
+                .json()
+                .await?;
+            
+            display_response(response);
+        }
+        RoleCommands::Get { slug } => {
+            let response: ApiResponse<Role> = client
+                .get(&format!("{}/roles/{}", BASE_URL, slug))
+                .send()
+                .await?
+                .json()
+                .await?;
+            
+            display_response(response);
+        }
+        RoleCommands::List => {
+            let response: ApiResponse<Vec<Role>> = client
+                .get(&format!("{}/roles", BASE_URL))
+                .send()
+                .await?
+                .json()
+                .await?;
+            
+            display_response(response);
+        }
+        RoleCommands::Update { slug, name } => {
+            let request = UpdateRoleRequest { name };
+            let response: ApiResponse<Role> = client
+                .put(&format!("{}/roles/{}", BASE_URL, slug))
+                .json(&request)
+                .send()
+                .await?
+                .json()
+                .await?;
+            
+            display_response(response);
+        }
+        RoleCommands::Delete { slug } => {
+            let response: ApiResponse<String> = client
+                .delete(&format!("{}/roles/{}", BASE_URL, slug))
+                .send()
+                .await?
+                .json()
+                .await?;
+            
+            display_response(response);
+        }
+    }
+    
+    Ok(())
+}
+
+async fn handle_user_role_commands(client: Client, action: UserRoleCommands) -> Result<(), Box<dyn std::error::Error>> {
+    match action {
+        UserRoleCommands::Add { user_id, role_slug } => {
+            let request = AddRoleToUserRequest { user_id, role_slug };
+            let response: ApiResponse<String> = client
+                .post(&format!("{}/users/{}/roles", BASE_URL, user_id))
+                .json(&request)
+                .send()
+                .await?
+                .json()
+                .await?;
+            
+            display_response(response);
+        }
+        UserRoleCommands::Remove { user_id, role_slug } => {
+            let response: ApiResponse<String> = client
+                .delete(&format!("{}/users/{}/roles/{}", BASE_URL, user_id, role_slug))
+                .send()
+                .await?
+                .json()
+                .await?;
+            
+            display_response(response);
+        }
+        UserRoleCommands::Get { user_id } => {
+            let response: ApiResponse<Vec<Role>> = client
+                .get(&format!("{}/users/{}/roles", BASE_URL, user_id))
+                .send()
+                .await?
+                .json()
+                .await?;
+            
+            display_response(response);
+        }
+    }
+    
+    Ok(())
+}
+
+fn display_response<T: serde::Serialize>(response: ApiResponse<T>) {
+    if response.success {
+        println!("✅ {}", response.message);
+        if let Some(data) = response.data {
+            println!("{}", serde_json::to_string_pretty(&data).unwrap());
+        }
+    } else {
+        eprintln!("❌ {}", response.message);
+        process::exit(1);
+    }
+}

--- a/4_backend/4_3_api/crates/server/Cargo.toml
+++ b/4_backend/4_3_api/crates/server/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "server"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+actix-web = "4.4"
+sqlx = { version = "0.7", features = ["postgres", "runtime-tokio-native-tls", "chrono"] }
+tokio = { version = "1.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+shared = { path = "../shared" }
+utoipa = { version = "4.0", features = ["actix_extras", "chrono"] }
+utoipa-swagger-ui = { version = "5.0", features = ["actix-web"] }  # Add features flag here

--- a/4_backend/4_3_api/crates/server/src/main.rs
+++ b/4_backend/4_3_api/crates/server/src/main.rs
@@ -1,0 +1,402 @@
+use actix_web::{web, App, HttpServer, Result, HttpResponse};
+use shared::{
+    User, CreateUserRequest, UpdateUserRequest, Role, CreateRoleRequest, UpdateRoleRequest,
+    AddRoleToUserRequest, ApiResponse,
+};
+use sqlx::{postgres::PgPoolOptions, Pool, Postgres};
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
+
+type DbPool = Pool<Postgres>;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        get_users,
+        create_user,
+        get_user,
+        update_user,
+        delete_user,
+        get_roles,
+        create_role,
+        get_role,
+        update_role,
+        delete_role,
+        get_user_roles,
+        add_role_to_user,
+        remove_role_from_user
+    ),
+    components(schemas(
+        User,
+        CreateUserRequest,
+        UpdateUserRequest,
+        Role,
+        CreateRoleRequest,
+        UpdateRoleRequest,
+        AddRoleToUserRequest,
+        ApiResponse<User>,
+        ApiResponse<Vec<User>>,
+        ApiResponse<Role>,
+        ApiResponse<Vec<Role>>,
+        ApiResponse<String>
+    ))
+)]
+struct ApiDoc;
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    // Database connection
+    let database_url = "postgres://rust_user:rust_password@localhost/rust_cli_app";
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect(database_url)
+        .await
+        .expect("Failed to connect to database");
+
+    println!("Connected to database successfully!");
+    println!("Server starting on http://localhost:8080");
+    println!("API Documentation: http://localhost:8080/swagger-ui/");
+
+    HttpServer::new(move || {
+        App::new()
+            .app_data(web::Data::new(pool.clone()))
+            .service(
+                SwaggerUi::new("/swagger-ui/{_:.*}")
+                    .url("/api-docs/openapi.json", ApiDoc::openapi()),
+            )
+            .service(get_users)
+            .service(create_user)
+            .service(get_user)
+            .service(update_user)
+            .service(delete_user)
+            .service(get_roles)
+            .service(create_role)
+            .service(get_role)
+            .service(update_role)
+            .service(delete_role)
+            .service(get_user_roles)
+            .service(add_role_to_user)
+            .service(remove_role_from_user)
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}
+
+// User endpoints
+#[utoipa::path(
+    get,
+    path = "/api/users",
+    responses(
+        (status = 200, description = "List of all users", body = ApiResponse<Vec<User>>)
+    )
+)]
+#[actix_web::get("/api/users")]
+async fn get_users(pool: web::Data<DbPool>) -> Result<HttpResponse> {
+    match sqlx::query_as::<_, User>("SELECT id, username, email, created_at FROM users ORDER BY id")
+        .fetch_all(pool.get_ref())
+        .await
+    {
+        Ok(users) => Ok(HttpResponse::Ok().json(ApiResponse::success(users, "Users retrieved successfully"))),
+        Err(e) => Ok(HttpResponse::InternalServerError().json(ApiResponse::<Vec<User>>::error(&format!("Failed to get users: {}", e)))),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/users",
+    request_body = CreateUserRequest,
+    responses(
+        (status = 201, description = "User created successfully", body = ApiResponse<User>),
+        (status = 400, description = "Bad request")
+    )
+)]
+#[actix_web::post("/api/users")]
+async fn create_user(
+    pool: web::Data<DbPool>,
+    user_data: web::Json<CreateUserRequest>,
+) -> Result<HttpResponse> {
+    match sqlx::query_as::<_, User>(
+        "INSERT INTO users (username, email) VALUES ($1, $2) RETURNING id, username, email, created_at"
+    )
+    .bind(&user_data.username)
+    .bind(&user_data.email)
+    .fetch_one(pool.get_ref())
+    .await
+    {
+        Ok(user) => Ok(HttpResponse::Created().json(ApiResponse::success(user, "User created successfully"))),
+        Err(e) => Ok(HttpResponse::BadRequest().json(ApiResponse::<User>::error(&format!("Failed to create user: {}", e)))),
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/users/{id}",
+    responses(
+        (status = 200, description = "User found", body = ApiResponse<User>),
+        (status = 404, description = "User not found")
+    )
+)]
+#[actix_web::get("/api/users/{id}")]
+async fn get_user(pool: web::Data<DbPool>, id: web::Path<i32>) -> Result<HttpResponse> {
+    match sqlx::query_as::<_, User>("SELECT id, username, email, created_at FROM users WHERE id = $1")
+        .bind(*id)
+        .fetch_optional(pool.get_ref())
+        .await
+    {
+        Ok(Some(user)) => Ok(HttpResponse::Ok().json(ApiResponse::success(user, "User found"))),
+        Ok(None) => Ok(HttpResponse::NotFound().json(ApiResponse::<User>::error("User not found"))),
+        Err(e) => Ok(HttpResponse::InternalServerError().json(ApiResponse::<User>::error(&format!("Failed to get user: {}", e)))),
+    }
+}
+
+#[utoipa::path(
+    put,
+    path = "/api/users/{id}",
+    request_body = UpdateUserRequest,
+    responses(
+        (status = 200, description = "User updated successfully", body = ApiResponse<User>),
+        (status = 404, description = "User not found")
+    )
+)]
+#[actix_web::put("/api/users/{id}")]
+async fn update_user(
+    pool: web::Data<DbPool>,
+    id: web::Path<i32>,
+    user_data: web::Json<UpdateUserRequest>,
+) -> Result<HttpResponse> {
+    match sqlx::query_as::<_, User>(
+        "UPDATE users SET username = $1 WHERE id = $2 RETURNING id, username, email, created_at"
+    )
+    .bind(&user_data.username)
+    .bind(*id)
+    .fetch_optional(pool.get_ref())
+    .await
+    {
+        Ok(Some(user)) => Ok(HttpResponse::Ok().json(ApiResponse::success(user, "User updated successfully"))),
+        Ok(None) => Ok(HttpResponse::NotFound().json(ApiResponse::<User>::error("User not found"))),
+        Err(e) => Ok(HttpResponse::InternalServerError().json(ApiResponse::<User>::error(&format!("Failed to update user: {}", e)))),
+    }
+}
+
+#[utoipa::path(
+    delete,
+    path = "/api/users/{id}",
+    responses(
+        (status = 200, description = "User deleted successfully", body = ApiResponse<String>),
+        (status = 404, description = "User not found")
+    )
+)]
+#[actix_web::delete("/api/users/{id}")]
+async fn delete_user(pool: web::Data<DbPool>, id: web::Path<i32>) -> Result<HttpResponse> {
+    match sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(*id)
+        .execute(pool.get_ref())
+        .await
+    {
+        Ok(result) if result.rows_affected() > 0 => {
+            Ok(HttpResponse::Ok().json(ApiResponse::success("".to_string(), "User deleted successfully")))
+        }
+        Ok(_) => Ok(HttpResponse::NotFound().json(ApiResponse::<String>::error("User not found"))),
+        Err(e) => Ok(HttpResponse::InternalServerError().json(ApiResponse::<String>::error(&format!("Failed to delete user: {}", e)))),
+    }
+}
+
+// Role endpoints
+#[utoipa::path(
+    get,
+    path = "/api/roles",
+    responses(
+        (status = 200, description = "List of all roles", body = ApiResponse<Vec<Role>>)
+    )
+)]
+#[actix_web::get("/api/roles")]
+async fn get_roles(pool: web::Data<DbPool>) -> Result<HttpResponse> {
+    match sqlx::query_as::<_, Role>("SELECT slug, name FROM roles ORDER BY slug")
+        .fetch_all(pool.get_ref())
+        .await
+    {
+        Ok(roles) => Ok(HttpResponse::Ok().json(ApiResponse::success(roles, "Roles retrieved successfully"))),
+        Err(e) => Ok(HttpResponse::InternalServerError().json(ApiResponse::<Vec<Role>>::error(&format!("Failed to get roles: {}", e)))),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/roles",
+    request_body = CreateRoleRequest,
+    responses(
+        (status = 201, description = "Role created successfully", body = ApiResponse<Role>),
+        (status = 400, description = "Bad request")
+    )
+)]
+#[actix_web::post("/api/roles")]
+async fn create_role(
+    pool: web::Data<DbPool>,
+    role_data: web::Json<CreateRoleRequest>,
+) -> Result<HttpResponse> {
+    match sqlx::query_as::<_, Role>(
+        "INSERT INTO roles (slug, name) VALUES ($1, $2) RETURNING slug, name"
+    )
+    .bind(&role_data.slug)
+    .bind(&role_data.name)
+    .fetch_one(pool.get_ref())
+    .await
+    {
+        Ok(role) => Ok(HttpResponse::Created().json(ApiResponse::success(role, "Role created successfully"))),
+        Err(e) => Ok(HttpResponse::BadRequest().json(ApiResponse::<Role>::error(&format!("Failed to create role: {}", e)))),
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/roles/{slug}",
+    responses(
+        (status = 200, description = "Role found", body = ApiResponse<Role>),
+        (status = 404, description = "Role not found")
+    )
+)]
+#[actix_web::get("/api/roles/{slug}")]
+async fn get_role(pool: web::Data<DbPool>, slug: web::Path<String>) -> Result<HttpResponse> {
+    match sqlx::query_as::<_, Role>("SELECT slug, name FROM roles WHERE slug = $1")
+        .bind(slug.into_inner())
+        .fetch_optional(pool.get_ref())
+        .await
+    {
+        Ok(Some(role)) => Ok(HttpResponse::Ok().json(ApiResponse::success(role, "Role found"))),
+        Ok(None) => Ok(HttpResponse::NotFound().json(ApiResponse::<Role>::error("Role not found"))),
+        Err(e) => Ok(HttpResponse::InternalServerError().json(ApiResponse::<Role>::error(&format!("Failed to get role: {}", e)))),
+    }
+}
+
+#[utoipa::path(
+    put,
+    path = "/api/roles/{slug}",
+    request_body = UpdateRoleRequest,
+    responses(
+        (status = 200, description = "Role updated successfully", body = ApiResponse<Role>),
+        (status = 404, description = "Role not found")
+    )
+)]
+#[actix_web::put("/api/roles/{slug}")]
+async fn update_role(
+    pool: web::Data<DbPool>,
+    slug: web::Path<String>,
+    role_data: web::Json<UpdateRoleRequest>,
+) -> Result<HttpResponse> {
+    match sqlx::query_as::<_, Role>(
+        "UPDATE roles SET name = $1 WHERE slug = $2 RETURNING slug, name"
+    )
+    .bind(&role_data.name)
+    .bind(slug.into_inner())
+    .fetch_optional(pool.get_ref())
+    .await
+    {
+        Ok(Some(role)) => Ok(HttpResponse::Ok().json(ApiResponse::success(role, "Role updated successfully"))),
+        Ok(None) => Ok(HttpResponse::NotFound().json(ApiResponse::<Role>::error("Role not found"))),
+        Err(e) => Ok(HttpResponse::InternalServerError().json(ApiResponse::<Role>::error(&format!("Failed to update role: {}", e)))),
+    }
+}
+
+#[utoipa::path(
+    delete,
+    path = "/api/roles/{slug}",
+    responses(
+        (status = 200, description = "Role deleted successfully", body = ApiResponse<String>),
+        (status = 404, description = "Role not found")
+    )
+)]
+#[actix_web::delete("/api/roles/{slug}")]
+async fn delete_role(pool: web::Data<DbPool>, slug: web::Path<String>) -> Result<HttpResponse> {
+    match sqlx::query("DELETE FROM roles WHERE slug = $1")
+        .bind(slug.into_inner())
+        .execute(pool.get_ref())
+        .await
+    {
+        Ok(result) if result.rows_affected() > 0 => {
+            Ok(HttpResponse::Ok().json(ApiResponse::success("".to_string(), "Role deleted successfully")))
+        }
+        Ok(_) => Ok(HttpResponse::NotFound().json(ApiResponse::<String>::error("Role not found"))),
+        Err(e) => Ok(HttpResponse::InternalServerError().json(ApiResponse::<String>::error(&format!("Failed to delete role: {}", e)))),
+    }
+}
+
+// User-Role relationship endpoints
+#[utoipa::path(
+    get,
+    path = "/api/users/{user_id}/roles",
+    responses(
+        (status = 200, description = "User roles retrieved", body = ApiResponse<Vec<Role>>),
+        (status = 404, description = "User not found")
+    )
+)]
+#[actix_web::get("/api/users/{user_id}/roles")]
+async fn get_user_roles(pool: web::Data<DbPool>, user_id: web::Path<i32>) -> Result<HttpResponse> {
+    match sqlx::query_as::<_, Role>(
+        "SELECT r.slug, r.name FROM roles r 
+         INNER JOIN users_roles ur ON r.slug = ur.role_slug 
+         WHERE ur.user_id = $1"
+    )
+    .bind(*user_id)
+    .fetch_all(pool.get_ref())
+    .await
+    {
+        Ok(roles) => Ok(HttpResponse::Ok().json(ApiResponse::success(roles, "User roles retrieved successfully"))),
+        Err(e) => Ok(HttpResponse::InternalServerError().json(ApiResponse::<Vec<Role>>::error(&format!("Failed to get user roles: {}", e)))),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/users/{user_id}/roles",
+    request_body = AddRoleToUserRequest,
+    responses(
+        (status = 201, description = "Role added to user successfully", body = ApiResponse<String>),
+        (status = 400, description = "Bad request")
+    )
+)]
+#[actix_web::post("/api/users/{user_id}/roles")]
+async fn add_role_to_user(
+    pool: web::Data<DbPool>,
+    user_id: web::Path<i32>,
+    request: web::Json<AddRoleToUserRequest>,
+) -> Result<HttpResponse> {
+    match sqlx::query("INSERT INTO users_roles (user_id, role_slug) VALUES ($1, $2)")
+        .bind(*user_id)
+        .bind(&request.role_slug)
+        .execute(pool.get_ref())
+        .await
+    {
+        Ok(_) => Ok(HttpResponse::Created().json(ApiResponse::success("".to_string(), "Role added to user successfully"))),
+        Err(e) => Ok(HttpResponse::BadRequest().json(ApiResponse::<String>::error(&format!("Failed to add role to user: {}", e)))),
+    }
+}
+
+#[utoipa::path(
+    delete,
+    path = "/api/users/{user_id}/roles/{role_slug}",
+    responses(
+        (status = 200, description = "Role removed from user successfully", body = ApiResponse<String>),
+        (status = 404, description = "Relationship not found")
+    )
+)]
+#[actix_web::delete("/api/users/{user_id}/roles/{role_slug}")]
+async fn remove_role_from_user(
+    pool: web::Data<DbPool>,
+    path: web::Path<(i32, String)>,
+) -> Result<HttpResponse> {
+    let (user_id, role_slug) = path.into_inner();
+    
+    match sqlx::query("DELETE FROM users_roles WHERE user_id = $1 AND role_slug = $2")
+        .bind(user_id)
+        .bind(role_slug)
+        .execute(pool.get_ref())
+        .await
+    {
+        Ok(result) if result.rows_affected() > 0 => {
+            Ok(HttpResponse::Ok().json(ApiResponse::success("".to_string(), "Role removed from user successfully")))
+        }
+        Ok(_) => Ok(HttpResponse::NotFound().json(ApiResponse::<String>::error("User-role relationship not found"))),
+        Err(e) => Ok(HttpResponse::InternalServerError().json(ApiResponse::<String>::error(&format!("Failed to remove role from user: {}", e)))),
+    }
+}

--- a/4_backend/4_3_api/crates/shared/Cargo.toml
+++ b/4_backend/4_3_api/crates/shared/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "shared"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde"] }
+utoipa = { version = "4.0", features = ["chrono"] }
+sqlx = { version = "0.7", features = ["postgres", "runtime-tokio-native-tls", "chrono"] }

--- a/4_backend/4_3_api/crates/shared/src/lib.rs
+++ b/4_backend/4_3_api/crates/shared/src/lib.rs
@@ -1,0 +1,72 @@
+use chrono::{NaiveDateTime};
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use utoipa::ToSchema;
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, FromRow)]
+pub struct User {
+    pub id: i32,
+    pub username: String,
+    pub email: String,
+    #[schema(value_type = String, format = DateTime)]
+    pub created_at: NaiveDateTime,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct CreateUserRequest {
+    pub username: String,
+    pub email: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct UpdateUserRequest {
+    pub username: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, FromRow)]
+pub struct Role {
+    pub slug: String,
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct CreateRoleRequest {
+    pub slug: String,
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct UpdateRoleRequest {
+    pub name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct AddRoleToUserRequest {
+    pub user_id: i32,
+    pub role_slug: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ApiResponse<T> {
+    pub success: bool,
+    pub data: Option<T>,
+    pub message: String,
+}
+
+impl<T> ApiResponse<T> {
+    pub fn success(data: T, message: &str) -> Self {
+        Self {
+            success: true,
+            data: Some(data),
+            message: message.to_string(),
+        }
+    }
+
+    pub fn error(message: &str) -> Self {
+        Self {
+            success: false,
+            data: None,
+            message: message.to_string(),
+        }
+    }
+}


### PR DESCRIPTION
Resolves [Step https://github.com/instrumentisto/rust-incubator/tree/main/4_backend/4_3_api)




## Task

Rework [the task from the previous step](https://github.com/instrumentisto/rust-incubator/blob/main/4_backend/4_2_http/README.md#task) in a ["thick client" paradigm](https://en.wikipedia.org/wiki/Rich_client):

    Server represents a [REST](https://en.wikipedia.org/wiki/Representational_state_transfer)ful [API](https://en.wikipedia.org/wiki/API) with separate endpoints for each operation.
    [CLI](https://en.wikipedia.org/wiki/Command-line_interface) client parses commands by itself and makes accurate requests to the server [REST](https://en.wikipedia.org/wiki/Representational_state_transfer)ful [API](https://en.wikipedia.org/wiki/API).

It should be possible to perform all the operations via [cURL](https://en.wikipedia.org/wiki/CURL) (or any other [HTTP](https://en.wikipedia.org/wiki/HTTP)/[API](https://en.wikipedia.org/wiki/API) client) directly on the [REST](https://en.wikipedia.org/wiki/Representational_state_transfer)ful [API](https://en.wikipedia.org/wiki/API) server, without using the [CLI](https://en.wikipedia.org/wiki/Command-line_interface) client.

Additionally, implement generation of [OpenAPI](https://en.wikipedia.org/wiki/OpenAPI_Specification) schema out of you server [REST](https://en.wikipedia.org/wiki/Representational_state_transfer)ful [API](https://en.wikipedia.org/wiki/API) code, and generate [HTML](https://en.wikipedia.org/wiki/HTML) documentation from the generated [OpenAPI](https://en.wikipedia.org/wiki/OpenAPI_Specification) schema.

Avoid architecture [over-engineering](https://en.wikipedia.org/wiki/Overengineering) for this task, just use simple, straightforward and obvious solutions.


## Solution

Used actix-web to create Server and all it's endpoints
used sqlx to work with database (queries are checked at runtime, not at compile time)

used utoipa  to create OpenAPI specifications and utoipa-swagger-ui to create nice html interface where all servers endpoints can be examined.
